### PR TITLE
Make the Odometer animation smoother

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,19 +2,20 @@
 <html>
   <head>
     <title>Life is Too Short for Meetings</title>
-    
+
     <script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
     <script src="odometer.min.js" type="text/javascript"></script>
+    <script>window.odometerOptions = { duration: 1000 };</script>
     <script src="random.js" type="text/javascript"></script>
-   
+
     <link rel="stylesheet" href="odometer-theme-default.css" type="text/css"  media="screen" charset="utf-8" />
     <link rel="stylesheet" href="dying.css" type="text/css"  media="screen" charset="utf-8" />
-   
+
     <link href="favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
     <link rel="apple-touch-icon-precomposed" href="apple-touch-icon-precomposed.png">
   </head>
 
-  <body>    
+  <body>
     <img class="skull shuffle" src="" alt="">
     <h1>Life Is Too Short <br><span style="color: #ff0066;">for Meetings</span></h1>
     <p><span style="color: #ffea00;">Every second, an average of 1.8 people die.</span><br> Since you loaded this page, this many people have died:</p>
@@ -24,22 +25,20 @@
     <script type="text/javascript">
     	$('.shuffle').randomImage();
     </script>
-    
-    <script type="text/javascript">
 
+    <script type="text/javascript">
       var deathToll = 0;
-      var frequency = 556
+      var frequency = 1000;
 
       var increaseDeathToll = function() {
-        deathToll += 1;
         $("#deathToll").text(deathToll);
-        setTimeout(increaseDeathToll, frequency)
+        deathToll += 1;
+        setTimeout(increaseDeathToll, frequency);
       }
 
-      $( document ).ready(function() {
-         setTimeout(increaseDeathToll,frequency);
+      $(document).ready(function(){
+        increaseDeathToll();
       });
-
     </script>
   </body>
 </html>

--- a/odometer-theme-default.css
+++ b/odometer-theme-default.css
@@ -68,11 +68,11 @@
   position: absolute;
 }
 .odometer.odometer-auto-theme.odometer-animating-up .odometer-ribbon-inner, .odometer.odometer-theme-default.odometer-animating-up .odometer-ribbon-inner {
-  -webkit-transition: -webkit-transform 2s;
-  -moz-transition: -moz-transform 2s;
-  -ms-transition: -ms-transform 2s;
-  -o-transition: -o-transform 2s;
-  transition: transform 2s;
+  -webkit-transition: -webkit-transform 1s linear;
+  -moz-transition: -moz-transform 1s linear;
+  -ms-transition: -ms-transform 1s linear;
+  -o-transition: -o-transform 1s linear;
+  transition: transform 1s linear;
 }
 .odometer.odometer-auto-theme.odometer-animating-up.odometer-animating .odometer-ribbon-inner, .odometer.odometer-theme-default.odometer-animating-up.odometer-animating .odometer-ribbon-inner {
   -webkit-transform: translateY(-100%);
@@ -89,11 +89,11 @@
   transform: translateY(-100%);
 }
 .odometer.odometer-auto-theme.odometer-animating-down.odometer-animating .odometer-ribbon-inner, .odometer.odometer-theme-default.odometer-animating-down.odometer-animating .odometer-ribbon-inner {
-  -webkit-transition: -webkit-transform 2s;
-  -moz-transition: -moz-transform 2s;
-  -ms-transition: -ms-transform 2s;
-  -o-transition: -o-transform 2s;
-  transition: transform 2s;
+  -webkit-transition: -webkit-transform 1s linear;
+  -moz-transition: -moz-transform 1s linear;
+  -ms-transition: -ms-transform 1s linear;
+  -o-transition: -o-transform 1s linear;
+  transition: transform 1s linear;
   -webkit-transform: translateY(0);
   -moz-transform: translateY(0);
   -ms-transform: translateY(0);


### PR DESCRIPTION
Thanks for using Odometer! Cool project.

I made a few changes to improve the smoothness of the ticker. Basically I set the `odometerOptions` and CSS to use  `1s` animation durations (instead of the default, which is `2s`). I also changed the `setTimeout` to call every `1000ms` instead of `556ms`.
